### PR TITLE
Release for v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.5.2](https://github.com/kaakaa/mattermost-plugin-reacji/compare/v0.5.1...v0.5.2) - 2024-05-04
+- Tagpr by @kaakaa in https://github.com/kaakaa/mattermost-plugin-reacji/pull/29
+
 ## [v0.5.1](https://github.com/kaakaa/mattermost-plugin-reacji/compare/v0.5.0...v0.5.1) - 2024-05-04
 - tagpr by @kaakaa in https://github.com/kaakaa/mattermost-plugin-reacji/pull/25
 - delete unnecessary file by @kaakaa in https://github.com/kaakaa/mattermost-plugin-reacji/pull/28


### PR DESCRIPTION
This pull request is for the next release as v0.5.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.5.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.5.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at master -->

## What's Changed
* Tagpr by @kaakaa in https://github.com/kaakaa/mattermost-plugin-reacji/pull/29


**Full Changelog**: https://github.com/kaakaa/mattermost-plugin-reacji/compare/v0.5.1...v0.5.2