### PR TITLE
Release for v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.5.3](https://github.com/kaakaa/mattermost-plugin-reacji/compare/v0.5.2...v0.5.3) - 2024-05-08
+- readme by @kaakaa in https://github.com/kaakaa/mattermost-plugin-reacji/pull/31
+- appbar by @kaakaa in https://github.com/kaakaa/mattermost-plugin-reacji/pull/34
+
 ## [v0.5.2](https://github.com/kaakaa/mattermost-plugin-reacji/compare/v0.5.1...v0.5.2) - 2024-05-04
 - Tagpr by @kaakaa in https://github.com/kaakaa/mattermost-plugin-reacji/pull/29
 

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "description": "Move post to other channel by attaching reactions",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-reacji",
     "support_url": "https://github.com/mattermost/mattermost-plugin-reacji/issues",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "min_server_version": "8.1.0",
     "server": {
         "executables": {


### PR DESCRIPTION
This pull request is for the next release as v0.5.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.5.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.5.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at master -->

## What's Changed
* readme by @kaakaa in https://github.com/kaakaa/mattermost-plugin-reacji/pull/31
* appbar by @kaakaa in https://github.com/kaakaa/mattermost-plugin-reacji/pull/34


**Full Changelog**: https://github.com/kaakaa/mattermost-plugin-reacji/compare/v0.5.2...v0.5.3